### PR TITLE
Set `serverless-http` and `@aws-sdk/client-s3` as peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.234.0",
     "@changesets/changelog-github": "^0.4.4",
     "@changesets/cli": "^2.22.0",
     "@tsconfig/node18": "^1.0.1",
@@ -26,13 +25,16 @@
     "@vercel/next": "^3.3.2",
     "esbuild": "^0.15.18",
     "node-fetch": "^3.3.0",
-    "serverless-http": "^3.1.0",
     "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.109",
     "@types/node": "^18.11.17",
     "typescript": "^4.9.3"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.234.0",
+    "serverless-http": "^3.1.0"
   },
   "bugs": {
     "url": "https://github.com/serverless-stack/open-next/issues"


### PR DESCRIPTION
These two packages are not specifically required to run open-next.

However, they are required in order for the lambda functions to be bundled correctly. Therefore, it makes sense to require them to be installed as dependencies of the Next.js application we are trying to bundle and not as dependencies of open-next itself.

This enables open-next to be used with stricter package managers such as `pnpm`.