### PR TITLE
fix: delete request body from server adapter

### DIFF
--- a/src/adapters/middleware-adapter.ts
+++ b/src/adapters/middleware-adapter.ts
@@ -67,6 +67,7 @@ function getMiddlewareRequestHeaders(response: any) {
   const headers: Record<string, string> = {};
   (response.headers.get("x-middleware-override-headers") || "")
     .split(",")
+    .filter(v => v)
     .forEach((key: string) => {
       headers[key] = response.headers.get(`x-middleware-request-${key}`)
     });

--- a/src/adapters/middleware-adapter.ts
+++ b/src/adapters/middleware-adapter.ts
@@ -67,7 +67,7 @@ function getMiddlewareRequestHeaders(response: any) {
   const headers: Record<string, string> = {};
   (response.headers.get("x-middleware-override-headers") || "")
     .split(",")
-    .filter(v => v)
+    .filter(Boolean)
     .forEach((key: string) => {
       headers[key] = response.headers.get(`x-middleware-request-${key}`)
     });

--- a/src/adapters/server-adapter.ts
+++ b/src/adapters/server-adapter.ts
@@ -19,7 +19,9 @@ console.log({ nextDir });
 
 // Create a NextServer
 const requestHandler = new NextServer.default({
-  conf: config,
+  // Next.js compression should be disabled because of a bug in the bundled
+  // `compression` package — https://github.com/vercel/next.js/issues/11669
+  conf: { ...config, compress: false },
   customServer: false,
   dev: false,
   dir: __dirname,

--- a/src/adapters/server-adapter.ts
+++ b/src/adapters/server-adapter.ts
@@ -19,9 +19,7 @@ console.log({ nextDir });
 
 // Create a NextServer
 const requestHandler = new NextServer.default({
-  // Next.js compression should be disabled because of a bug in the bundled
-  // `compression` package — https://github.com/vercel/next.js/issues/11669
-  conf: { ...config, compress: false },
+  conf: config,
   customServer: false,
   dev: false,
   dir: __dirname,

--- a/src/adapters/server-adapter.ts
+++ b/src/adapters/server-adapter.ts
@@ -50,7 +50,6 @@ const server = slsHttp(
   {
     binary: true,
     provider: "aws",
-
     request: (request: any) => {
       // nextjs doesn't parse body if the property exists
       // https://github.com/dougmoscrop/serverless-http/issues/227

--- a/src/adapters/server-adapter.ts
+++ b/src/adapters/server-adapter.ts
@@ -50,6 +50,12 @@ const server = slsHttp(
   {
     binary: true,
     provider: "aws",
+
+    request: (request: any) => {
+      // nextjs doesn't parse body if the property exists
+      // https://github.com/dougmoscrop/serverless-http/issues/227
+      delete request.body;
+    },
   },
 );
 


### PR DESCRIPTION
This PR fixes some issues:

1) Nextjs doesn't parse the body if it already exists on the request object: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/api-utils/node.ts#L474

2) If a header has a space it in, the custom header ends up w/ `null` fields

3) `compress: false` has been fixed in the latest nextjs version.

EDIT: Do not merge yet
