### PR TITLE
fix: Fix next-auth middleware not working on Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ Vercel uses the `Headers.getAll()` function in its middleware code, but this fun
 
 We decided to go with option 1 because it does not require an addition dependency and it is possible that Vercel will remove the use of the `getAll()` function in the future.
 
+#### WORKAROUND: NextAuth Middleware
+
+`next-auth` uses `jose`, which is bundled oddly. For example, it assumes `crypto` and `CryptoKey` are globally available. To handle this, we inject `crypto` and `CryptoKey` into the `globalThis` instance to circumvent this issue.
+
+
 ## Example
 
 In the `example` folder, you can find a Next.js feature test app. It contains a variety of pages that each test a single Next.js feature.

--- a/README.md
+++ b/README.md
@@ -282,10 +282,9 @@ Vercel uses the `Headers.getAll()` function in its middleware code, but this fun
 
 We decided to go with option 1 because it does not require an addition dependency and it is possible that Vercel will remove the use of the `getAll()` function in the future.
 
-#### WORKAROUND: NextAuth Middleware
+#### WORKAROUND: Polyfill `crypto` for the middleware function
 
-`next-auth` uses `jose`, which is bundled oddly. For example, it assumes `crypto` and `CryptoKey` are globally available. To handle this, we inject `crypto` and `CryptoKey` into the `globalThis` instance to circumvent this issue.
-
+[NextAuth.js](https://next-auth.js.org) uses the [`jose`](https://github.com/panva/jose) library at runtime to encrypt and decrypt JWT tokens. The library, in turn, uses the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API). This workaround polyfills `crypto` and `CryptoKey` into the `globalThis` instance.
 
 ## Example
 

--- a/src/adapters/image-optimization-adapter.ts
+++ b/src/adapters/image-optimization-adapter.ts
@@ -1,60 +1,63 @@
-import path from "node:path"
-import https from "node:https"
-import { Writable } from "node:stream"
-import { IncomingMessage, ServerResponse } from "node:http"
-import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3"
+import path from "node:path";
+import https from "node:https";
+import { Writable } from "node:stream";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import type {
-	APIGatewayProxyEventV2,
-	APIGatewayProxyResultV2,
-	APIGatewayProxyEventHeaders,
-	APIGatewayProxyEventQueryStringParameters
-} from "aws-lambda"
+  APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
+  APIGatewayProxyEventHeaders,
+  APIGatewayProxyEventQueryStringParameters,
+} from "aws-lambda";
 // @ts-ignore
-import { defaultConfig } from "next/dist/server/config-shared"
+import { defaultConfig } from "next/dist/server/config-shared";
 // @ts-ignore
-import type { NextUrlWithParsedQuery } from "next/dist/server/request-meta"
-// @ts-ignore
-import { imageOptimizer, ImageOptimizerCache } from "next/dist/server/image-optimizer"
-import { loadConfig } from "./util.js"
+import type { NextUrlWithParsedQuery } from "next/dist/server/request-meta";
+import {
+  imageOptimizer,
+  ImageOptimizerCache,
+  // @ts-ignore
+} from "next/dist/server/image-optimizer";
+
+import { loadConfig } from "./util.js";
 
 const bucketName = process.env.BUCKET_NAME;
 const nextDir = path.join(__dirname, ".next");
 const config = loadConfig(nextDir);
 const nextConfig = {
-	...(defaultConfig),
-	images: {
-		...(defaultConfig.images),
-		...config.images,
-	},
-}
+  ...defaultConfig,
+  images: {
+    ...defaultConfig.images,
+    ...config.images,
+  },
+};
 console.log("Init config", {
-	nextDir,
-	bucketName,
-	nextConfig,
+  nextDir,
+  bucketName,
+  nextConfig,
 });
 
 /////////////
 // Handler //
 /////////////
 
-export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
-	// Images are handled via header and query param information.
-	console.log("handler event", event)
-	const {
-		headers: rawHeaders,
-		queryStringParameters: queryString,
-	} = event;
+export async function handler(
+  event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyResultV2> {
+  // Images are handled via header and query param information.
+  console.log("handler event", event);
+  const { headers: rawHeaders, queryStringParameters: queryString } = event;
 
-	try {
-		const headers = normalizeHeaderKeysToLowercase(rawHeaders)
-		ensureBucketExists();
-		const imageParams = validateImageParams(headers, queryString);
-		const result = await optimizeImage(headers, imageParams);
+  try {
+    const headers = normalizeHeaderKeysToLowercase(rawHeaders);
+    ensureBucketExists();
+    const imageParams = validateImageParams(headers, queryString);
+    const result = await optimizeImage(headers, imageParams);
 
-		return buildSuccessResponse(result);
-	} catch (e: any) {
-		return buildFailureResponse(e);
-	}
+    return buildSuccessResponse(result);
+  } catch (e: any) {
+    return buildFailureResponse(e);
+  }
 }
 
 //////////////////////
@@ -62,137 +65,139 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
 //////////////////////
 
 function normalizeHeaderKeysToLowercase(headers: APIGatewayProxyEventHeaders) {
-	// Make header keys lowercase to ensure integrity
-	return Object.entries(headers).reduce((acc, [key, value]) =>
-		({ ...acc, [key.toLowerCase()]: value }),
-		{} as APIGatewayProxyEventHeaders
-	)
+  // Make header keys lowercase to ensure integrity
+  return Object.entries(headers).reduce(
+    (acc, [key, value]) => ({ ...acc, [key.toLowerCase()]: value }),
+    {} as APIGatewayProxyEventHeaders
+  );
 }
 
 function ensureBucketExists() {
-	if (!bucketName) {
-		throw new Error("Bucket name must be defined!")
-	}
+  if (!bucketName) {
+    throw new Error("Bucket name must be defined!");
+  }
 }
 
 function validateImageParams(
-	headers: APIGatewayProxyEventHeaders,
-	queryString?: APIGatewayProxyEventQueryStringParameters
+  headers: APIGatewayProxyEventHeaders,
+  queryString?: APIGatewayProxyEventQueryStringParameters
 ) {
-	// Next.js checks if external image URL matches the
-	// `images.remotePatterns`
-	const imageParams = ImageOptimizerCache.validateParams(
-		{ headers },
-		queryString,
-		nextConfig,
-		false
-	);
-	console.log("image params", imageParams);
-	if ("errorMessage" in imageParams) {
-		throw new Error(imageParams.errorMessage)
-	}
-	return imageParams;
+  // Next.js checks if external image URL matches the
+  // `images.remotePatterns`
+  const imageParams = ImageOptimizerCache.validateParams(
+    { headers },
+    queryString,
+    nextConfig,
+    false
+  );
+  console.log("image params", imageParams);
+  if ("errorMessage" in imageParams) {
+    throw new Error(imageParams.errorMessage);
+  }
+  return imageParams;
 }
 
 async function optimizeImage(
-	headers: APIGatewayProxyEventHeaders,
-	imageParams: any
+  headers: APIGatewayProxyEventHeaders,
+  imageParams: any
 ) {
-	const result = await imageOptimizer(
-		{ headers },
-		{}, // res object is not necessary as it's not actually used.
-		imageParams,
-		nextConfig,
-		false, // not in dev mode
-		downloadHandler,
-	)
-	console.log("optimized result", result);
-	return result;
+  const result = await imageOptimizer(
+    { headers },
+    {}, // res object is not necessary as it's not actually used.
+    imageParams,
+    nextConfig,
+    false, // not in dev mode
+    downloadHandler
+  );
+  console.log("optimized result", result);
+  return result;
 }
 
 function buildSuccessResponse(result: any) {
-	return {
-		statusCode: 200,
-		body: result.buffer.toString("base64"),
-		isBase64Encoded: true,
-		headers: {
-			Vary: "Accept",
-			"Cache-Control": `public,max-age=${result.maxAge},immutable`,
-			"Content-Type": result.contentType,
-		},
-	};
+  return {
+    statusCode: 200,
+    body: result.buffer.toString("base64"),
+    isBase64Encoded: true,
+    headers: {
+      Vary: "Accept",
+      "Cache-Control": `public,max-age=${result.maxAge},immutable`,
+      "Content-Type": result.contentType,
+    },
+  };
 }
 
 function buildFailureResponse(e: any) {
-	console.error(e)
-	return {
-		statusCode: 500,
-		headers: {
-			Vary: "Accept",
-			// For failed images, allow client to retry after 1 minute. 
-			"Cache-Control": `public,max-age=60,immutable`,
-			"Content-Type": "application/json"
-		},
-		body: e?.message || e?.toString() || e
-	}
+  console.error(e);
+  return {
+    statusCode: 500,
+    headers: {
+      Vary: "Accept",
+      // For failed images, allow client to retry after 1 minute.
+      "Cache-Control": `public,max-age=60,immutable`,
+      "Content-Type": "application/json",
+    },
+    body: e?.message || e?.toString() || e,
+  };
 }
 
 async function downloadHandler(
-	_req: IncomingMessage,
-	res: ServerResponse,
-	url: NextUrlWithParsedQuery
+  _req: IncomingMessage,
+  res: ServerResponse,
+  url: NextUrlWithParsedQuery
 ) {
-	// downloadHandler is called by Next.js. We don't call this function
-	// directly.
-	console.log("downloadHandler url", url);
+  // downloadHandler is called by Next.js. We don't call this function
+  // directly.
+  console.log("downloadHandler url", url);
 
-	// Reads the output from the Writable and writes to the response
-	const pipeRes = (w: Writable, res: ServerResponse) => {
-		w.pipe(res)
-			.once("close", () => {
-				res.statusCode = 200
-				res.end()
-			})
-			.once("error", (err) => {
-				console.error("Failed to get image", { err })
-				res.statusCode = 400
-				res.end()
-			})
-	}
+  // Reads the output from the Writable and writes to the response
+  const pipeRes = (w: Writable, res: ServerResponse) => {
+    w.pipe(res)
+      .once("close", () => {
+        res.statusCode = 200;
+        res.end();
+      })
+      .once("error", (err) => {
+        console.error("Failed to get image", { err });
+        res.statusCode = 400;
+        res.end();
+      });
+  };
 
-	try {
-		// Case 1: remote image URL => download the image from the URL
-		if (url.href.toLowerCase().match(/^https?:\/\//)) {
-			pipeRes(https.get(url), res)
-		}
-		// Case 2: local image => download the image from S3
-		else {
-			// Download image from S3
-			// note: S3 expects keys without leading `/`
-			const client = new S3Client({})
-			const response = await client.send(new GetObjectCommand({
-				Bucket: bucketName,
-				Key: url.href.replace(/^\//, ""),
-			}));
+  try {
+    // Case 1: remote image URL => download the image from the URL
+    if (url.href.toLowerCase().match(/^https?:\/\//)) {
+      pipeRes(https.get(url), res);
+    }
+    // Case 2: local image => download the image from S3
+    else {
+      // Download image from S3
+      // note: S3 expects keys without leading `/`
+      const client = new S3Client({});
+      const response = await client.send(
+        new GetObjectCommand({
+          Bucket: bucketName,
+          Key: url.href.replace(/^\//, ""),
+        })
+      );
 
-			if (!response.Body) {
-				throw new Error("Empty response body from the S3 request.")
-			}
+      if (!response.Body) {
+        throw new Error("Empty response body from the S3 request.");
+      }
 
-			// @ts-ignore
-			pipeRes(response.Body, res);
+      // @ts-ignore
+      pipeRes(response.Body, res);
 
-			// Respect the bucket file's content-type and cache-control
-			// imageOptimizer will use this to set the results.maxAge
-			if (response.ContentType) {
-				res.setHeader("Content-Type", response.ContentType)
-			}
-			if (response.CacheControl) {
-				res.setHeader("Cache-Control", response.CacheControl)
-			}
-		}
-	} catch (e: any) {
-		console.error("Failed to download image", e)
-		throw e;
-	}
+      // Respect the bucket file's content-type and cache-control
+      // imageOptimizer will use this to set the results.maxAge
+      if (response.ContentType) {
+        res.setHeader("Content-Type", response.ContentType);
+      }
+      if (response.CacheControl) {
+        res.setHeader("Cache-Control", response.CacheControl);
+      }
+    }
+  } catch (e: any) {
+    console.error("Failed to download image", e);
+    throw e;
+  }
 }

--- a/src/adapters/middleware-adapter.ts
+++ b/src/adapters/middleware-adapter.ts
@@ -1,13 +1,15 @@
 import type {
   CloudFrontRequestEvent,
   CloudFrontRequestResult,
-  CloudFrontHeaders
-} from "aws-lambda"
+  CloudFrontHeaders,
+} from "aws-lambda";
 
 // @ts-ignore
 const index = await (() => import("./middleware.js"))();
 
-export async function handler(event: CloudFrontRequestEvent): Promise<CloudFrontRequestResult> {
+export async function handler(
+  event: CloudFrontRequestEvent
+): Promise<CloudFrontRequestResult> {
   const request = event.Records[0].cf.request;
   const { uri, method, headers, querystring, body } = request;
   console.log(uri);
@@ -20,7 +22,7 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
   for (const [key, values] of Object.entries(headers)) {
     for (const { value } of values) {
       if (value) {
-        requestHeaders.append(key, value)
+        requestHeaders.append(key, value);
       }
     }
   }
@@ -40,31 +42,30 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
 
   // Process request
   const response = await index.default(nodeRequest, {
-    waitUntil: () => { },
+    waitUntil: () => {},
   });
   console.log("middleware response header", response.headers);
 
   // WORKAROUND: Pass headers from middleware function to server function (AWS specific) — https://github.com/serverless-stack/open-next#workaround-pass-headers-from-middleware-function-to-server-function-aws-specific
   if (response.headers.get("x-middleware-next") === "1") {
-    headers["x-op-middleware-request-headers"] = [{
-      key: "x-op-middleware-request-headers",
-      value: getMiddlewareRequestHeaders(response),
-    }];
-    headers["x-op-middleware-response-headers"] = [{
-      key: "x-op-middleware-response-headers",
-      value: getMiddlewareResponseHeaders(response),
-    }];
+    headers["x-op-middleware-request-headers"] = [
+      {
+        key: "x-op-middleware-request-headers",
+        value: getMiddlewareRequestHeaders(response),
+      },
+    ];
+    headers["x-op-middleware-response-headers"] = [
+      {
+        key: "x-op-middleware-response-headers",
+        value: getMiddlewareResponseHeaders(response),
+      },
+    ];
     return request;
   }
 
-  // In the case where `middleware.ts` response w/ a body, send that back to the client
-  let responseBody
-  const state = Object.getOwnPropertySymbols(response).find(s => s.toString() === 'Symbol(state)')
-  if (state) responseBody = response[state]?.body?.source
-
   return {
     status: response.status,
-    body: responseBody,
+    body: response.body ? await response.text() : undefined,
     headers: httpHeadersToCfHeaders(response.headers),
   };
 }
@@ -75,7 +76,7 @@ function getMiddlewareRequestHeaders(response: any) {
     .split(",")
     .filter(Boolean)
     .forEach((key: string) => {
-      headers[key] = response.headers.get(`x-middleware-request-${key}`)
+      headers[key] = response.headers.get(`x-middleware-request-${key}`);
     });
   console.log("getMiddlewareRequestHeaders", headers);
   return JSON.stringify(headers);

--- a/src/adapters/middleware-adapter.ts
+++ b/src/adapters/middleware-adapter.ts
@@ -57,8 +57,14 @@ export async function handler(event: CloudFrontRequestEvent): Promise<CloudFront
     return request;
   }
 
+  // In the case where `middleware.ts` response w/ a body, send that back to the client
+  let responseBody
+  const state = Object.getOwnPropertySymbols(response).find(s => s.toString() === 'Symbol(state)')
+  if (state) responseBody = response[state]?.body?.source
+
   return {
     status: response.status,
+    body: responseBody,
     headers: httpHeadersToCfHeaders(response.headers),
   };
 }

--- a/src/adapters/server-adapter.ts
+++ b/src/adapters/server-adapter.ts
@@ -1,15 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
 import { IncomingMessage, ServerResponse } from "node:http";
-import slsHttp from "serverless-http"
+import slsHttp from "serverless-http";
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyResultV2,
   Context,
-} from "aws-lambda"
+} from "aws-lambda";
 // @ts-ignore
 import NextServer from "next/dist/server/next-server.js";
-import { loadConfig } from "./util.js"
+import { loadConfig } from "./util.js";
 
 setNextjsServerWorkingDirectory();
 const nextDir = path.join(__dirname, ".next");
@@ -37,15 +37,21 @@ const requestHandler = new NextServer.default({
 const server = slsHttp(
   async (req: IncomingMessage, res: ServerResponse) => {
     await requestHandler(req, res).catch((e: any) => {
-      console.error("NextJS request failed.")
-      console.error(e)
+      console.error("NextJS request failed.");
+      console.error(e);
 
-      res.setHeader("Content-Type", "application/json")
-      res.end(JSON.stringify({
-        message: "Server failed to respond.",
-        details: e,
-      }, null, 2))
-    })
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify(
+          {
+            message: "Server failed to respond.",
+            details: e,
+          },
+          null,
+          2
+        )
+      );
+    });
   },
   {
     binary: true,
@@ -55,15 +61,18 @@ const server = slsHttp(
       // https://github.com/dougmoscrop/serverless-http/issues/227
       delete request.body;
     },
-  },
+  }
 );
 
 /////////////
 // Handler //
 /////////////
 
-export async function handler(event: APIGatewayProxyEventV2, context: Context): Promise<APIGatewayProxyResultV2> {
-  console.log(event)
+export async function handler(
+  event: APIGatewayProxyEventV2,
+  context: Context
+): Promise<APIGatewayProxyResultV2> {
+  console.log(event);
 
   // WORKAROUND: Pass headers from middleware function to server function (AWS specific) — https://github.com/serverless-stack/open-next#workaround-pass-headers-from-middleware-function-to-server-function-aws-specific
   const middlewareRequestHeaders = JSON.parse(
@@ -75,8 +84,12 @@ export async function handler(event: APIGatewayProxyEventV2, context: Context): 
   const response: APIGatewayProxyResultV2 = await server(event, context);
 
   // WORKAROUND: `NextServer` does not set cache response headers for HTML pages — https://github.com/serverless-stack/open-next#workaround-nextserver-does-not-set-cache-response-headers-for-html-pages
-  if (htmlPages.includes(event.rawPath) && !response.headers?.["cache-control"]) {
-    response.headers!["cache-control"] = "public, max-age=0, s-maxage=31536000, must-revalidate";
+  if (
+    htmlPages.includes(event.rawPath) &&
+    !response.headers?.["cache-control"]
+  ) {
+    response.headers!["cache-control"] =
+      "public, max-age=0, s-maxage=31536000, must-revalidate";
   }
 
   // WORKAROUND: Pass headers from middleware function to server function (AWS specific) — https://github.com/serverless-stack/open-next#workaround-pass-headers-from-middleware-function-to-server-function-aws-specific

--- a/src/build.ts
+++ b/src/build.ts
@@ -35,7 +35,9 @@ function checkRunningInsideNextjsApp() {
     fs.existsSync(path.join(appPath, `next.config.${ext}`))
   );
   if (!extension) {
-    console.error("Error: next.config.js not found. Please make sure you are running this command inside a Next.js app.");
+    console.error(
+      "Error: next.config.js not found. Please make sure you are running this command inside a Next.js app."
+    );
     process.exit(1);
   }
 }
@@ -43,9 +45,11 @@ function checkRunningInsideNextjsApp() {
 function findMonorepoRoot() {
   let currentPath = appPath;
   while (currentPath !== "/") {
-    if (fs.existsSync(path.join(currentPath, "package-lock.json"))
-      || fs.existsSync(path.join(currentPath, "yarn.lock"))
-      || fs.existsSync(path.join(currentPath, "pnpm-lock.yaml"))) {
+    if (
+      fs.existsSync(path.join(currentPath, "package-lock.json")) ||
+      fs.existsSync(path.join(currentPath, "yarn.lock")) ||
+      fs.existsSync(path.join(currentPath, "pnpm-lock.yaml"))
+    ) {
       if (currentPath !== appPath) {
         console.info("Monorepo detected at", currentPath);
       }
@@ -81,13 +85,15 @@ function buildNextjsApp(monorepoRoot: string) {
 
 function printHeader(header: string) {
   header = `OpenNext — ${header}`;
-  console.info([
-    "",
-    "┌" + "─".repeat(header.length + 2) + "┐",
-    `│ ${header} │`,
-    "└" + "─".repeat(header.length + 2) + "┘",
-    "",
-  ].join("\n"));
+  console.info(
+    [
+      "",
+      "┌" + "─".repeat(header.length + 2) + "┐",
+      `│ ${header} │`,
+      "└" + "─".repeat(header.length + 2) + "┘",
+      "",
+    ].join("\n")
+  );
 }
 
 function printVersion() {
@@ -103,7 +109,12 @@ function initOutputDir() {
 
 function getMiddlewareName() {
   // note: middleware can be at the root or inside "src"
-  const filePath = path.join(appPath, ".next", "server", "middleware-manifest.json");
+  const filePath = path.join(
+    appPath,
+    ".next",
+    "server",
+    "middleware-manifest.json"
+  );
   const json = fs.readFileSync(filePath, "utf-8");
   return JSON.parse(json).middleware?.["/"]?.name;
 }
@@ -118,11 +129,10 @@ function createServerBundle(monorepoRoot: string) {
   // Copy over standalone output files
   // note: if user uses pnpm as the package manager, node_modules contain
   //       symlinks. We don't want to resolve the symlinks when copying.
-  fs.cpSync(
-    path.join(appPath, ".next/standalone"),
-    path.join(outputPath),
-    { recursive: true, verbatimSymlinks: true }
-  );
+  fs.cpSync(path.join(appPath, ".next/standalone"), path.join(outputPath), {
+    recursive: true,
+    verbatimSymlinks: true,
+  });
 
   // Resolve path to the Next.js app if inside the monorepo
   // note: if user's app is inside a monorepo, standalone mode places
@@ -134,10 +144,7 @@ function createServerBundle(monorepoRoot: string) {
 
   // Standalone output already has a Node server "server.js", remove it.
   // It will be replaced with the Lambda handler.
-  fs.rmSync(
-    path.join(outputPath, packagePath, "server.js"),
-    { force: true }
-  );
+  fs.rmSync(path.join(outputPath, packagePath, "server.js"), { force: true });
 
   // Build Lambda code
   // note: bundle in OpenNext package b/c the adatper relys on the
@@ -162,10 +169,11 @@ function createServerBundle(monorepoRoot: string) {
   //       the root of the bundle. We will create a dummy `index.mjs`
   //       that re-exports the real handler.
   if (isMonorepo) {
-    fs.writeFileSync(path.join(outputPath, "index.mjs"), [
-      `export * from "./${packagePath}/index.mjs";`,
-    ].join(""))
-  };
+    fs.writeFileSync(
+      path.join(outputPath, "index.mjs"),
+      [`export * from "./${packagePath}/index.mjs";`].join("")
+    );
+  }
 }
 
 function createImageOptimizationBundle() {
@@ -180,7 +188,9 @@ function createImageOptimizationBundle() {
   //       "@aws-sdk/client-s3" package which is not a dependency in user's
   //       Next.js app.
   esbuildSync({
-    entryPoints: [path.join(__dirname, "adapters", "image-optimization-adapter.js")],
+    entryPoints: [
+      path.join(__dirname, "adapters", "image-optimization-adapter.js"),
+    ],
     external: ["sharp", "next"],
     outfile: path.join(outputPath, "index.mjs"),
   });
@@ -208,7 +218,7 @@ function createImageOptimizationBundle() {
   fs.mkdirSync(path.join(outputPath, ".next"));
   fs.copyFileSync(
     path.join(appPath, ".next/required-server-files.json"),
-    path.join(outputPath, ".next/required-server-files.json"),
+    path.join(outputPath, ".next/required-server-files.json")
   );
 
   // Copy over sharp node modules
@@ -223,9 +233,11 @@ function createMiddlewareBundle(buildOutput: any) {
   const middlewareName = getMiddlewareName();
   if (middlewareName) {
     console.info(`Bundling middleware edge function...`);
-  }
-  else {
-    console.info(`Bundling middleware edge function... \x1b[36m%s\x1b[0m`, "skipped");
+  } else {
+    console.info(
+      `Bundling middleware edge function... \x1b[36m%s\x1b[0m`,
+      "skipped"
+    );
     return;
   }
 
@@ -238,7 +250,7 @@ function createMiddlewareBundle(buildOutput: any) {
   fs.writeFileSync(path.join(tempDir, "middleware.js"), src);
   fs.copyFileSync(
     path.join(__dirname, "adapters", "middleware-adapter.js"),
-    path.join(tempDir, "middleware-adapter.js"),
+    path.join(tempDir, "middleware-adapter.js")
   );
 
   // Build Lambda code
@@ -248,8 +260,6 @@ function createMiddlewareBundle(buildOutput: any) {
     banner: {
       js: [
         // WORKAROUND: Add `Headers.getAll()` extension to the middleware function — https://github.com/serverless-stack/open-next#workaround-add-headersgetall-extension-to-the-middleware-function
-        // WORKAROUND: Add `crypto` and `CryptoKey` for next-auth middleware - https://github.com/serverless-stack/open-next#workaround-nextauth-middleware
-        "import crypto from 'node:crypto';",
         "class Response extends globalThis.Response {",
         "  constructor(body, init) {",
         "    super(body, init);",
@@ -264,12 +274,15 @@ function createMiddlewareBundle(buildOutput: any) {
         "    };",
         "  }",
         "}",
-        // Polyfill Response and self
+        "Object.assign(globalThis, {",
+        "  Response,",
+        "  self: {},",
+        "});",
+        // WORKAROUND: Polyfill `crypto` for the middleware function (NextAuth specific) - https://github.com/serverless-stack/open-next#workaround-polyfill-crypto-for-the-middleware-function
+        "import crypto from 'node:crypto';",
         "Object.assign(globalThis, {",
         "  crypto,",
         "  CryptoKey: crypto.webcrypto.CryptoKey,",
-        "  Response,",
-        "  self: {},",
         "});",
       ].join(""),
     },
@@ -297,11 +310,7 @@ function createAssets() {
     path.join(outputPath, "_next", "static"),
     { recursive: true }
   );
-  fs.cpSync(
-    path.join(appPath, "public"),
-    outputPath,
-    { recursive: true }
-  );
+  fs.cpSync(path.join(appPath, "public"), outputPath, { recursive: true });
 }
 
 function esbuildSync(options: BuildOptions) {
@@ -316,6 +325,8 @@ function esbuildSync(options: BuildOptions) {
 
   if (result.errors.length > 0) {
     result.errors.forEach((error) => console.error(error));
-    throw new Error(`There was a problem bundling ${(options.entryPoints as string[])[0]}.`);
+    throw new Error(
+      `There was a problem bundling ${(options.entryPoints as string[])[0]}.`
+    );
   }
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -248,6 +248,8 @@ function createMiddlewareBundle(buildOutput: any) {
     banner: {
       js: [
         // WORKAROUND: Add `Headers.getAll()` extension to the middleware function — https://github.com/serverless-stack/open-next#workaround-add-headersgetall-extension-to-the-middleware-function
+        // WORKAROUND: Add `crypto` and `CryptoKey` for next-auth middleware - https://github.com/serverless-stack/open-next#workaround-nextauth-middleware
+        "import crypto from 'node:crypto';",
         "class Response extends globalThis.Response {",
         "  constructor(body, init) {",
         "    super(body, init);",
@@ -264,6 +266,8 @@ function createMiddlewareBundle(buildOutput: any) {
         "}",
         // Polyfill Response and self
         "Object.assign(globalThis, {",
+        "  crypto,",
+        "  CryptoKey: crypto.webcrypto.CryptoKey,",
         "  Response,",
         "  self: {},",
         "});",
@@ -306,6 +310,7 @@ function esbuildSync(options: BuildOptions) {
     format: "esm",
     platform: "node",
     bundle: true,
+    minify: true,
     ...options,
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ const command = process.argv[2];
 
 if (command === "build") {
   build();
-}
-else {
+} else {
   console.log("Unknown command");
   console.log("");
   console.log("Usage:");


### PR DESCRIPTION
This PR allows `next-auth/middleware` to properly run in Lambda environment.

When using this w/ NextjsSitev2 you will probably get infinite redirects due to the way the CloudFront Distribution is set up. To get around this, you can make changes to NextjsSite, eg:
NOTE: there's a limit of 25 cache behaviors, so if you need more than that just request a quota upgrade and you should easily get several hundred. 

```typescript
    createCloudFrontDistributionForRegional() {
       ...
        const baseServerBehavior = {
            viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
            origin: new origins.HttpOrigin(Fn.parseDomainName(fnUrl.url)),
            allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
            cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS,
            compress: true,

            cachePolicy: cdk?.cachePolicies?.serverRequests ??
                this.createCloudFrontServerCachePolicy(),
        };
        const middlewareBehavior = {
            ...baseServerBehavior,
            edgeLambdas: isMiddlewareEnabled ? [{
                eventType: cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
                functionVersion: middlewareFn.currentVersion,
                includeBody: true
            }] : undefined
            }
        const serverBehavior = {
            ...baseServerBehavior
        }
        const middlewareRoutes = this.getMiddlewareRoutes(middlewareBehavior)
       ...
       additionalBehaviors: {
                ...middlewareRoutes,
                "_next/data/*": serverBehavior,
                "_next/image*": imageBehavior,
                "_next/*": staticFileBehaviour,
                ...(cfDistributionProps.additionalBehaviors || {}),
            },
    }
    // create middleware behavior only for the matcher defined in middleware.ts
    getMiddlewareRoutes(behavior) {
        const middlewareManifest = path.join(this.props.path, '.next/server/middleware-manifest.json')
        const content = fs.readFileSync(middlewareManifest).toString('utf8')
        const obj = JSON.parse(content)
        const matcher = obj.middleware['/'].matchers
        const routes = {}
    
        matcher.forEach((reg) => {
          let path = reg.regexp
            .replace('^(?:\\/(_next\\/data\\/[^/]{1,}))?', '')
            .replace('(.json)?[\\/#\\?]?$', '')
            .replace('(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?', '/*')
            .replaceAll('\\', '')
            .replace(/^\//, '')
          routes[path] = behavior
        })
    
        return routes
    }
```

Or you can not use the `default` middleware and read the token manually:
NOTE: the current NextjsSite distribution will route *all* requests to middleware... this should be fixed in the future per logic above.

This will guard all your `/api` endpoints:
```typescript
import { NextRequest, NextResponse } from 'next/server'
import { getToken } from 'next-auth/jwt'

export async function middleware(req: NextRequest) {
     const pathname = req.nextUrl.pathname
     // /api/auth shouldn't be restricted or else user will never be able to login
     if (!pathname.startsWith('/api/auth/') && pathname.startsWith('/api/')) { // add your own path checks
       const token = await getToken({ req })
       if (!token) {
         return new NextResponse('Unauthorized', {
           status: 401,
           headers: { 'content-type': 'text/plain' }
         })
      }
    }
}
```