### PR TITLE
Image Optimization Lambda: Add bucket key prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Create a Lambda function using the code in the `.open-next/image-optimization-fu
 
 - Set the architecture to `arm64`.
 - Set the `BUCKET_NAME` environment variable with the value being the name of the S3 bucket where the original images are stored.
+- Set the `BUCKET_KEY_PREFIX` environment variable with the value being a key prefix on the S3 bucket if the assets are on a prefix.
 - Grant `s3:GetObject` permission.
 
 This function handles image optimization requests when the Next.js `<Image>` component is used. The [sharp](https://www.npmjs.com/package/sharp) library, which is bundled with the function, is used to convert the image. The library is compiled against the `arm64` architecture and is intended to run on AWS Lambda Arm/Graviton2 architecture. [Learn about the better cost-performance offered by AWS Graviton2 processors.](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/)

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -178,10 +178,11 @@ async function downloadHandler(
       // Download image from S3
       // note: S3 expects keys without leading `/`
       const client = new S3Client({});
+      const keyPrefix = (process.env.BUCKET_KEY_PREFIX || "").replace(/^\//, "");
       const response = await client.send(
         new GetObjectCommand({
           Bucket: bucketName,
-          Key: url.href.replace(/^\//, ""),
+          Key: keyPrefix + (keyPrefix.endsWith("/") ? "" : "/") + url.href.replace(/^\//, ""),
         })
       );
 


### PR DESCRIPTION
Adds an environment variable (`BUCKET_KEY_PREFIX`) that enables a bucket key prefix for the image lambda.

When unset, it does not modify the key and when set, takes care of all the `/` that need to be there or dissapear for it to be a valid S3 key.

Edit: Related to #65.