### PR TITLE
open-next build no longer fail on missing public folder

### DIFF
--- a/.changeset/spicy-moose-brush.md
+++ b/.changeset/spicy-moose-brush.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Support Next.js apps without "public" folder

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -6,6 +6,7 @@ import { buildSync, BuildOptions } from "esbuild";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const appPath = process.cwd();
+const appPublicPath = path.join(appPath, "public");
 const outputDir = ".open-next";
 const tempDir = path.join(outputDir, ".build");
 
@@ -115,15 +116,14 @@ function initOutputDir() {
 }
 
 function listPublicFiles() {
-  const publicPath = path.join(appPath, "public");
   const result: PublicFiles = { files: [] };
 
-  if (!fs.existsSync(publicPath)) {
+  if (!fs.existsSync(appPublicPath)) {
     return result;
   }
 
   function processDirectory(pathInPublic: string) {
-    const files = fs.readdirSync(path.join(publicPath, pathInPublic), {
+    const files = fs.readdirSync(path.join(appPublicPath, pathInPublic), {
       withFileTypes: true,
     });
 
@@ -277,9 +277,8 @@ function createAssets() {
     path.join(outputPath, "_next", "static"),
     { recursive: true }
   );
-  const publicPath = path.join(appPath, "public");
-  if (fs.existsSync(publicPath)) {
-    fs.cpSync(publicPath, outputPath, { recursive: true });
+  if (fs.existsSync(appPublicPath)) {
+    fs.cpSync(appPublicPath, outputPath, { recursive: true });
   }
 }
 

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -116,12 +116,13 @@ function readTopLevelPublicFilesAndDirs() {
   const publicPath = path.join(appPath, "public");
 
   const items: PublicAssets = {};
-
-  fs.readdirSync(publicPath).map((file) => {
-    items[`/${file}`] = fs.statSync(path.join(publicPath, file)).isDirectory()
-      ? "dir"
-      : "file";
-  });
+  if (fs.existsSync(publicPath)) {
+    fs.readdirSync(publicPath).map((file) => {
+      items[`/${file}`] = fs.statSync(path.join(publicPath, file)).isDirectory()
+        ? "dir"
+        : "file";
+    });
+  }
   return items;
 }
 
@@ -264,7 +265,10 @@ function createAssets() {
     path.join(outputPath, "_next", "static"),
     { recursive: true }
   );
-  fs.cpSync(path.join(appPath, "public"), outputPath, { recursive: true });
+  const publicPath = path.join(appPath, "public");
+  if (fs.existsSync(publicPath)) {
+    fs.cpSync(publicPath, outputPath, { recursive: true });
+  }
 }
 
 function esbuildSync(options: BuildOptions) {


### PR DESCRIPTION
This makes it possible to run open-next without a public folder created