### PR TITLE
fix: Safecheck Object.entries for APIGatewayProxyEventHeaders

### DIFF
--- a/.changeset/nervous-bananas-remember.md
+++ b/.changeset/nervous-bananas-remember.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+server: handle API Gateway REST API event without multiValueHeaders

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -260,18 +260,14 @@ function normalizeAPIGatewayProxyEventHeaders(
   event.multiValueHeaders;
   const headers: Record<string, string> = {};
 
-  if (event.multiValueHeaders) {
-    for (const [key, values] of Object.entries(event.multiValueHeaders)) {
-      if (values) {
-        headers[key.toLowerCase()] = values.join(",");
-      }
+  for (const [key, values] of Object.entries(event.multiValueHeaders || {})) {
+    if (values) {
+      headers[key.toLowerCase()] = values.join(",");
     }
   }
-  if (event.headers) {
-    for (const [key, value] of Object.entries(event.headers)) {
-      if (value) {
-        headers[key.toLowerCase()] = value;
-      }
+  for (const [key, value] of Object.entries(event.headers || {})) {
+    if (value) {
+      headers[key.toLowerCase()] = value;
     }
   }
   return headers;

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -267,9 +267,11 @@ function normalizeAPIGatewayProxyEventHeaders(
       }
     }
   }
+  if (event.headers) {
     for (const [key, value] of Object.entries(event.headers)) {
       if (value) {
         headers[key.toLowerCase()] = value;
+      }
     }
   }
   return headers;

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -260,14 +260,16 @@ function normalizeAPIGatewayProxyEventHeaders(
   event.multiValueHeaders;
   const headers: Record<string, string> = {};
 
-  for (const [key, values] of Object.entries(event.multiValueHeaders)) {
-    if (values) {
-      headers[key.toLowerCase()] = values.join(",");
+  if (event.multiValueHeaders) {
+    for (const [key, values] of Object.entries(event.multiValueHeaders)) {
+      if (values) {
+        headers[key.toLowerCase()] = values.join(",");
+      }
     }
   }
-  for (const [key, value] of Object.entries(event.headers)) {
-    if (value) {
-      headers[key.toLowerCase()] = value;
+    for (const [key, value] of Object.entries(event.headers)) {
+      if (value) {
+        headers[key.toLowerCase()] = value;
     }
   }
   return headers;


### PR DESCRIPTION
Simply adds some checks that the fields exist before  attempting  to iterate over them with Object.entries

as requested in discord:
https://discord.com/channels/983865673656705025/1027265626085019769/1098297764359700500