### PR TITLE
Update event-mapper.ts

### DIFF
--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -243,13 +243,6 @@ function normalizeAPIGatewayProxyEventQueryParams(
       }
     }
   }
-  if (event.queryStringParameters) {
-    for (const [key, value] of Object.entries(event.queryStringParameters)) {
-      if (value !== undefined) {
-        params.append(key, value);
-      }
-    }
-  }
   const value = params.toString();
   return value ? `?${value}` : "";
 }


### PR DESCRIPTION
v1 event contain all params in multiValueQueryStringParameters. Atm there is a bug where all params get duplicated in when sent to next.

eg an input path to the api gw: `/?step=1` becomes `/step=1&step=1` after we reconstruct the query params from the v1 event. The solution in this PR i to just check the multiValueQueryStringParameters object as that one will be populated even in cases where there isn't any multi-values. 