### PR TITLE
Allow custom build command

### DIFF
--- a/.changeset/tricky-beds-live.md
+++ b/.changeset/tricky-beds-live.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Add custom build commands

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ When calling `open-next build`, OpenNext **runs `next build`** to build the Next
 
 #### Building the Next.js app
 
-OpenNext runs the `build` script in your `package.json` file. Depending on the lock file found in the app, the corresponding packager manager will be used. Either `npm run build`, `yarn build`, or `pnpm build` will be run.
+By default, OpenNext runs the `build` script in your `package.json` file. Depending on the lock file found in the app, the corresponding packager manager will be used. Either `npm run build`, `yarn build`, or `pnpm build` will be run.
+
+If you want to use a custom build command, use `open-next build [custom command]`, for example `open-next build customBuild`.
 
 #### Transforming the build output
 

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -15,7 +15,11 @@ export type PublicFiles = {
   files: string[];
 };
 
-export async function build() {
+export type BuildArguments = {
+  buildCommand: string;
+};
+
+export async function build(buildArguments: BuildArguments) {
   // Pre-build validation
   printVersion();
   checkRunningInsideNextjsApp();
@@ -24,7 +28,7 @@ export async function build() {
   // Build Next.js app
   printHeader("Building Next.js app");
   setStandaloneBuildMode(monorepoRoot);
-  await buildNextjsApp(packager);
+  await buildNextjsApp(packager, buildArguments);
 
   // Generate deployable bundle
   printHeader("Generating bundle");
@@ -80,10 +84,10 @@ function setStandaloneBuildMode(monorepoRoot: string) {
   process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT = monorepoRoot;
 }
 
-function buildNextjsApp(packager: "npm" | "yarn" | "pnpm") {
+function buildNextjsApp(packager: "npm" | "yarn" | "pnpm", buildArguments: BuildArguments) {
   const result = cp.spawnSync(
     packager,
-    packager === "npm" ? ["run", "build"] : ["build"],
+    packager === "npm" ? ["run", buildArguments.buildCommand] : [buildArguments.buildCommand],
     {
       stdio: "inherit",
       cwd: appPath,

--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
 
-import { build } from "./build.js";
+import { BuildArguments, build } from "./build.js";
 
 const command = process.argv[2];
 
 if (command === "build") {
-  build();
+  const buildArguments: BuildArguments = {
+    buildCommand: process.argv[3] ? process.argv[3] : "build",
+  }
+  build(buildArguments);
 } else {
   console.log("Unknown command");
   console.log("");
   console.log("Usage:");
-  console.log("  npx open-next build");
+  console.log("  npx open-next build [custom build command]");
   console.log("");
 }

--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -7,6 +7,7 @@ const command = process.argv[2];
 if (command === "build") {
   const buildArguments: BuildArguments = {
     buildCommand: process.argv[3] ? process.argv[3] : "build",
+    appPath: ".",
   }
   build(buildArguments);
 } else {


### PR DESCRIPTION
Allow for custom build commands to be specified. `package.json`'s `build` keeps being the default in case the custom one is empty.

New usage would be `open-next build [custom build command]`.

For example, if we have the `customBuild` command in our `package.json`, we will run OpenNext like `open-next build customBuild`.

I have created the `BuildArguments` type so new arguments can be added down the line.