### PR TITLE
fix: fix next not using prebundled react library

### DIFF
--- a/.changeset/dirty-apricots-shout.md
+++ b/.changeset/dirty-apricots-shout.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Set `__NEXT_PRIVATE_PREBUNDLED_REACT` to use prebundled React

--- a/README.md
+++ b/README.md
@@ -357,6 +357,14 @@ In this case, `path.join(process.cwd(), "posts", "my-post.md")` cannot be resolv
 
 To work around the issue, we change the working directory for the server function to where `.next/` is located, ie. `packages/web`.
 
+#### WORKAROUND: Set `__NEXT_PRIVATE_PREBUNDLED_REACT` to use prebundled React
+
+For Next.js 13.2 and later versions, you need to explicitly set the `__NEXT_PRIVATE_PREBUNDLED_REACT` environment variable. Although this environment variable isn't documented at the time of writing, you can refer to the Next.js source code to understand its usage:
+
+> In standalone mode, we don't have separated render workers so if both app and pages are used, we need to resolve to the prebundled React to ensure the correctness of the version for app.
+
+> Require these modules with static paths to make sure they are tracked by NFT when building the app in standalone mode, as we are now conditionally aliasing them it's tricky to track them in build time.
+
 ## Example
 
 In the `example` folder, you can find a Next.js benchmark app. It contains a variety of pages that each test a single Next.js feature. The app is deployed to both Vercel and AWS using [SST](https://docs.sst.dev/start/nextjs).

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -22,10 +22,12 @@ import {
 import { loadConfig, setNodeEnv } from "./util.js";
 import { debug } from "./logger.js";
 
+const bucketName = process.env.BUCKET_NAME;
+
 const nextDir = path.join(__dirname, ".next");
 const config = loadConfig(nextDir);
+
 setNodeEnv(config);
-const bucketName = process.env.BUCKET_NAME;
 
 const nextConfig = {
   ...defaultConfig,

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -22,13 +22,10 @@ import {
 import { loadConfig, setNodeEnv } from "./util.js";
 import { debug } from "./logger.js";
 
+setNodeEnv();
 const bucketName = process.env.BUCKET_NAME;
-
 const nextDir = path.join(__dirname, ".next");
 const config = loadConfig(nextDir);
-
-setNodeEnv(config);
-
 const nextConfig = {
   ...defaultConfig,
   images: {

--- a/packages/open-next/src/adapters/image-optimization-adapter.ts
+++ b/packages/open-next/src/adapters/image-optimization-adapter.ts
@@ -21,12 +21,12 @@ import {
 } from "next/dist/server/image-optimizer";
 import { loadConfig, setNodeEnv } from "./util.js";
 import { debug } from "./logger.js";
-import { convertFrom, isAPIGatewayProxyEvent } from "./event-mapper.js";
 
-setNodeEnv();
-const bucketName = process.env.BUCKET_NAME;
 const nextDir = path.join(__dirname, ".next");
 const config = loadConfig(nextDir);
+setNodeEnv(config);
+const bucketName = process.env.BUCKET_NAME;
+
 const nextConfig = {
   ...defaultConfig,
   images: {

--- a/packages/open-next/src/adapters/next-types.ts
+++ b/packages/open-next/src/adapters/next-types.ts
@@ -1,0 +1,33 @@
+// NOTE: add more next config typings as they become relevant
+
+type RemotePattern = {
+  protocol?: "http" | "https";
+  hostname: string;
+  port?: string;
+  pathname?: string;
+};
+declare type ImageFormat = "image/avif" | "image/webp";
+
+type ImageConfigComplete = {
+  deviceSizes: number[];
+  imageSizes: number[];
+  path: string;
+  loaderFile: string;
+  domains: string[];
+  disableStaticImages: boolean;
+  minimumCacheTTL: number;
+  formats: ImageFormat[];
+  dangerouslyAllowSVG: boolean;
+  contentSecurityPolicy: string;
+  contentDispositionType: "inline" | "attachment";
+  remotePatterns: RemotePattern[];
+  unoptimized: boolean;
+};
+type ImageConfig = Partial<ImageConfigComplete>;
+
+export interface NextConfig {
+  experimental: {
+    serverActions?: boolean;
+  };
+  images: ImageConfig;
+}

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -30,8 +30,9 @@ debug({ nextDir });
 const requestHandler = new NextServer.default({
   hostname: "localhost",
   port: Number(process.env.PORT) || 3000,
-  conf: config,
+  conf: {...config, compress: false},
   customServer: false,
+  dev: false,
   dir: __dirname,
 }).getRequestHandler();
 

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -15,16 +15,14 @@ import { debug } from "./logger.js";
 import type { PublicFiles } from "../build.js";
 import { convertFrom, convertTo } from "./event-mapper.js";
 
+setNodeEnv();
+setNextjsServerWorkingDirectory();
 const nextDir = path.join(__dirname, ".next");
 const openNextDir = path.join(__dirname, ".open-next");
 const config = loadConfig(nextDir);
-
-setNodeEnv(config);
-
-setNextjsServerWorkingDirectory();
-
 const htmlPages = loadHtmlPages();
 const publicAssets = loadPublicAssets();
+setNextjsPrebundledReact(config);
 debug({ nextDir });
 
 // Create a NextServer
@@ -110,6 +108,14 @@ export async function handler(
 function setNextjsServerWorkingDirectory() {
   // WORKAROUND: Set `NextServer` working directory (AWS specific) — https://github.com/serverless-stack/open-next#workaround-set-nextserver-working-directory-aws-specific
   process.chdir(__dirname);
+}
+
+function setNextjsPrebundledReact(config: any) {
+  // WORKAROUND: Set `__NEXT_PRIVATE_PREBUNDLED_REACT` to use prebundled React — https://github.com/serverless-stack/open-next#workaround-set-__next_private_prebundled_react-to-use-prebundled-react
+  process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = config.experimental
+    .serverActions
+    ? "experimental"
+    : "next";
 }
 
 function loadHtmlPages() {

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -15,11 +15,13 @@ import { debug } from "./logger.js";
 import type { PublicFiles } from "../build.js";
 import { convertFrom, convertTo } from "./event-mapper.js";
 
-setNodeEnv();
-setNextjsServerWorkingDirectory();
 const nextDir = path.join(__dirname, ".next");
 const openNextDir = path.join(__dirname, ".open-next");
 const config = loadConfig(nextDir);
+
+setNodeEnv(config);
+setNextjsServerWorkingDirectory();
+
 const htmlPages = loadHtmlPages();
 const publicAssets = loadPublicAssets();
 debug({ nextDir });
@@ -28,11 +30,8 @@ debug({ nextDir });
 const requestHandler = new NextServer.default({
   hostname: "localhost",
   port: Number(process.env.PORT) || 3000,
-  // Next.js compression should be disabled because of a bug in the bundled
-  // `compression` package — https://github.com/vercel/next.js/issues/11669
-  conf: { ...config, compress: false },
+  conf: config,
   customServer: false,
-  dev: false,
   dir: __dirname,
 }).getRequestHandler();
 

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -20,6 +20,7 @@ const openNextDir = path.join(__dirname, ".open-next");
 const config = loadConfig(nextDir);
 
 setNodeEnv(config);
+
 setNextjsServerWorkingDirectory();
 
 const htmlPages = loadHtmlPages();
@@ -30,7 +31,9 @@ debug({ nextDir });
 const requestHandler = new NextServer.default({
   hostname: "localhost",
   port: Number(process.env.PORT) || 3000,
-  conf: {...config, compress: false},
+  // Next.js compression should be disabled because of a bug in the bundled
+  // `compression` package — https://github.com/vercel/next.js/issues/11669
+  conf: { ...config, compress: false },
   customServer: false,
   dev: false,
   dir: __dirname,

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -1,49 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
+import type { NextConfig } from "./next-types.js";
 
-type RemotePattern = {
-    protocol?: 'http' | 'https';
-    hostname: string;
-    port?: string;
-    pathname?: string;
-};
-declare type ImageFormat = 'image/avif' | 'image/webp';
-
-type ImageConfigComplete = {
-    deviceSizes: number[];
-    imageSizes: number[];
-    path: string;
-    loaderFile: string;
-    domains: string[];
-    disableStaticImages: boolean;
-    minimumCacheTTL: number;
-    formats: ImageFormat[];
-    dangerouslyAllowSVG: boolean;
-    contentSecurityPolicy: string;
-    contentDispositionType: 'inline' | 'attachment';
-    remotePatterns: RemotePattern[];
-    unoptimized: boolean;
-};
-type ImageConfig = Partial<ImageConfigComplete>;
-
-// NOTE: add more next config typings as they become relevant
-interface NextConfig {
-  experimental: {
-    serverActions?: boolean
-  },
-  images: ImageConfig
-}
-
-export function setNodeEnv(config: NextConfig) {
+export function setNodeEnv() {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
-  // NOTE: 13.2 and above requires "__NEXT_PRIVATE_PREBUNDLED_REACT" to be explicitly set
-  process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = config.experimental.serverActions ? 'experimental' : 'next';
 }
 
-
-export function loadConfig(nextDir: string): NextConfig {
+export function loadConfig(nextDir: string) {
   const filePath = path.join(nextDir, "required-server-files.json");
   const json = fs.readFileSync(filePath, "utf-8");
   const { config } = JSON.parse(json);
-  return config satisfies NextConfig;
+  return config as NextConfig;
 }

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -1,15 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 
-
-type ImageLoaderProps = {
-    src: string;
-    width: number;
-    quality?: number;
-};
-type ImageLoaderPropsWithConfig = ImageLoaderProps & {
-    config: Readonly<ImageConfig>;
-};
 type RemotePattern = {
     protocol?: 'http' | 'https';
     hostname: string;

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -1,13 +1,58 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export function setNodeEnv() {
-  process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
+
+type ImageLoaderProps = {
+    src: string;
+    width: number;
+    quality?: number;
+};
+type ImageLoaderPropsWithConfig = ImageLoaderProps & {
+    config: Readonly<ImageConfig>;
+};
+type RemotePattern = {
+    protocol?: 'http' | 'https';
+    hostname: string;
+    port?: string;
+    pathname?: string;
+};
+declare type ImageFormat = 'image/avif' | 'image/webp';
+
+type ImageConfigComplete = {
+    deviceSizes: number[];
+    imageSizes: number[];
+    path: string;
+    loaderFile: string;
+    domains: string[];
+    disableStaticImages: boolean;
+    minimumCacheTTL: number;
+    formats: ImageFormat[];
+    dangerouslyAllowSVG: boolean;
+    contentSecurityPolicy: string;
+    contentDispositionType: 'inline' | 'attachment';
+    remotePatterns: RemotePattern[];
+    unoptimized: boolean;
+};
+type ImageConfig = Partial<ImageConfigComplete>;
+
+// NOTE: add more next config typings as they become relevant
+interface NextConfig {
+  experimental: {
+    serverActions?: boolean
+  },
+  images: ImageConfig
 }
 
-export function loadConfig(nextDir: string) {
+export function setNodeEnv(config: NextConfig) {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
+  // NOTE: 13.2 and above requires "__NEXT_PRIVATE_PREBUNDLED_REACT" to be explicitly set
+  process.env.__NEXT_PRIVATE_PREBUNDLED_REACT = config.experimental.serverActions ? 'experimental' : 'next';
+}
+
+
+export function loadConfig(nextDir: string): NextConfig {
   const filePath = path.join(nextDir, "required-server-files.json");
   const json = fs.readFileSync(filePath, "utf-8");
   const { config } = JSON.parse(json);
-  return config;
+  return config satisfies NextConfig;
 }

--- a/packages/open-next/tsconfig.json
+++ b/packages/open-next/tsconfig.json
@@ -5,6 +5,6 @@
     "module": "esnext",
     "moduleResolution": "nodenext",
     "outDir": "./dist",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
   }
 }

--- a/packages/open-next/tsconfig.json
+++ b/packages/open-next/tsconfig.json
@@ -5,6 +5,6 @@
     "module": "esnext",
     "moduleResolution": "nodenext",
     "outDir": "./dist",
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": true
   }
 }


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/49168/files#diff-7550a61853cf6a2d455d1613bd428eb42c6fc2057ce87e8ba7adab4094abcb6e

Next 13.1 and below had a bug where it would use the precompiled next library. 13.2+ fixes it so open-next needs to explicitly set the `NEXT_PRIVATE_PREBUNDLED_REACT` flat to `"next"`