### PR TITLE
fix: skip next build with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,14 @@ OPEN_NEXT_MINIFY=true open-next build
 
 Enabling this option can significantly help to reduce the cold start time of the server function. However, it's an **experimental feature**, and you need to opt-in to use it. Once this option is thoroughly tested and found to be stable, it will be enabled by default.
 
+#### OPEN_NEXT_SKIP_BUILD
+You can skip OpenNext from running the build command by setting the `OPEN_NEXT_SKIP_BUILD` environment variable:
+
+```bash
+OPEN_NEXT_SKIP_BUILD=1
+```
+*This requires building your application before running OpenNext.
+
 ## Debugging
 
 To find the **server and image optimization log**, go to the AWS CloudWatch console in the **region you deployed to**.

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -24,7 +24,9 @@ export async function build() {
   // Build Next.js app
   printHeader("Building Next.js app");
   setStandaloneBuildMode(monorepoRoot);
-  await buildNextjsApp(packager);
+  if (typeof process.env.OPEN_NEXT_SKIP_BUILD === 'undefined') {
+    await buildNextjsApp(packager);
+  }
 
   // Generate deployable bundle
   printHeader("Generating bundle");


### PR DESCRIPTION
This Pull request aims to solve the problem discussed in the issue: #63 

The fix only add a conditional checking for a environment variable. 

I have also expirience in my pipelines another issue that this solution can be aplied as a workaround. For some reason when I run the sst deploy and next build is runned as a child_process from open-next executed from sst deploy, my pipeline hangs in: "Creating an optimized production build..."

![Captura de tela 2023-05-11 143816](https://github.com/serverless-stack/open-next/assets/31905169/8b7e6a96-3a38-433e-a3be-1b2932db3951)
