### PR TITLE
fix: response throwing error due to javascript bug

### DIFF
--- a/.changeset/polite-rice-learn.md
+++ b/.changeset/polite-rice-learn.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+server: support ArrayBuffer response

--- a/packages/open-next/src/adapters/response.ts
+++ b/packages/open-next/src/adapters/response.ts
@@ -11,24 +11,24 @@ const BODY = Symbol();
 const HEADERS = Symbol();
 
 function getString(data) {
-  if (Buffer.isBuffer(data)) {
+  if (Buffer.isBuffer(data) || ArrayBuffer.isView(data)) {
     return data.toString("utf8");
   } else if (typeof data === "string") {
     return data;
   } else {
-    throw new Error(`response.write() of unexpected type: ${typeof data}`);
+    throw new Error(`response.getString() of unexpected type: ${typeof data}`);
   }
 }
 
 function addData(stream, data) {
   if (
     Buffer.isBuffer(data) ||
-    typeof data === "string" ||
-    data instanceof Uint8Array
+    ArrayBuffer.isView(data) ||
+    typeof data === "string"
   ) {
     stream[BODY].push(Buffer.from(data));
   } else {
-    throw new Error(`response.write() of unexpected type: ${typeof data}`);
+    throw new Error(`response.addData() of unexpected type: ${typeof data}`);
   }
 }
 

--- a/packages/open-next/src/adapters/response.ts
+++ b/packages/open-next/src/adapters/response.ts
@@ -11,6 +11,9 @@ const BODY = Symbol();
 const HEADERS = Symbol();
 
 function getString(data) {
+  // Note: use `ArrayBuffer.isView()` to check for Uint8Array. Using
+  //       `instanceof Uint8Array` returns false in some cases. For example,
+  //       when the buffer is created in middleware and passed to NextServer.
   if (Buffer.isBuffer(data)) {
     return data.toString("utf8");
   } else if (ArrayBuffer.isView(data)) {

--- a/packages/open-next/src/adapters/response.ts
+++ b/packages/open-next/src/adapters/response.ts
@@ -11,8 +11,10 @@ const BODY = Symbol();
 const HEADERS = Symbol();
 
 function getString(data) {
-  if (Buffer.isBuffer(data) || ArrayBuffer.isView(data)) {
+  if (Buffer.isBuffer(data)) {
     return data.toString("utf8");
+  } else if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data).toString("utf8");
   } else if (typeof data === "string") {
     return data;
   } else {


### PR DESCRIPTION
When using NextResponse in middleware, the Uint8Array instance type becomes corrupted in some way due to cross realm context????
eg:
```
return new NextResponse(JSON.stringify({})), {status: 200, headers: {'content-type': 'application/json'}})
```

The `data instanceof Uint8Array` returns false b/c the data traveled far across realms: middleware => server


per chatGPT:

```
The expression `uint8Array instanceof Uint8Array` can sometimes return `false` in JavaScript due to the way objects and prototypes work.

In JavaScript, the `instanceof` operator checks if an object is an instance of a specific constructor. It traverses the prototype chain of the object to determine if the object inherits from the specified constructor's prototype.

However, there are situations where the prototype chain can be modified or the object's constructor can be changed, which can lead to unexpected results when using the `instanceof` operator.

Here are a few possible reasons why `uint8Array instanceof Uint8Array` may return `false`:

1. Context or Cross-Realm Issues: If the `Uint8Array` constructor used to create the `uint8Array` object comes from a different JavaScript context or realm than the one where the `instanceof` check is performed, it can result in `false`. Each context or realm has its own set of built-in constructors, including `Uint8Array`, and they are not shared across different contexts.

2. Prototype Modifications: If the prototype of `Uint8Array` or any of its parent prototypes is modified, the `instanceof` check may no longer produce the expected result.

3. Shadowing: If the `Uint8Array` constructor or its prototype is shadowed or overridden by a different constructor or object, the `instanceof` check may not work as intended.

To ensure consistent and reliable type checking, it's generally recommended to use other methods such as `ArrayBuffer.isView()` or `ArrayBuffer.isView(uint8Array)` to specifically check if an object is a typed array, like `Uint8Array`. These methods are more reliable for type checking typed array objects.

Example:

```javascript
const isUint8Array = ArrayBuffer.isView(uint8Array) && uint8Array.constructor === Uint8Array;
console.log(isUint8Array); // true
```

In this example, we use `ArrayBuffer.isView()` to check if the `uint8Array` is a typed array, and then verify if its constructor matches `Uint8Array`.

By using specific methods for type checking, you can avoid potential issues with the `instanceof` operator.
```