### PR TITLE
Fix react dependencies resolution

### DIFF
--- a/.changeset/flat-monkeys-behave.md
+++ b/.changeset/flat-monkeys-behave.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+server: Fix react dependencies resolution

--- a/packages/open-next/src/adapters/next-types.ts
+++ b/packages/open-next/src/adapters/next-types.ts
@@ -35,3 +35,13 @@ export interface NextConfig {
   };
   images: ImageConfig;
 }
+
+interface RouteDefinition {
+  page: string;
+  regex: string;
+}
+
+export interface RoutesManifest {
+  dynamicRoutes: RouteDefinition[];
+  staticRoutes: RouteDefinition[];
+}

--- a/packages/open-next/src/adapters/require-hooks.ts
+++ b/packages/open-next/src/adapters/require-hooks.ts
@@ -11,10 +11,9 @@ const resolveFilename = mod._resolveFilename;
 const hookPropertyMapApp = new Map();
 const hookPropertyMapPage = new Map();
 
-export function addHookAliases(
-  aliases: [string, string][] = [],
-  type: "app" | "page"
-) {
+type Alias = [string, string];
+
+export function addHookAliases(aliases: Alias[] = [], type: "app" | "page") {
   for (const [key, value] of aliases) {
     type === "app"
       ? hookPropertyMapApp.set(key, value)
@@ -31,28 +30,14 @@ export function overrideDefault() {
       ["styled-jsx", require.resolve("styled-jsx")],
       ["styled-jsx/style", require.resolve("styled-jsx/style")],
       ["styled-jsx/style", require.resolve("styled-jsx/style")],
-      ["server-only", require.resolve("next/dist/compiled/server-only")],
-      ["client-only", require.resolve("next/dist/compiled/client-only")],
     ],
     "app"
   );
 }
 
 // Override built-in React packages if necessary
-export function overrideReact(config: NextConfig) {
-  addHookAliases(
-    [
-      ["react", `/var/task/node_modules/react`],
-      ["react/jsx-runtime", `/var/task/node_modules/react/jsx-runtime`],
-      ["react/jsx-dev-runtime", `/var/task/node_modules/react/jsx-dev-runtime`],
-      ["react-dom", `/var/task/node_modules/react-dom`],
-      [
-        "react-dom/server.browser",
-        `/var/task/node_modules/react-dom/server.browser`,
-      ],
-    ],
-    "page"
-  );
+export function overrideReact(config: NextConfig, pageDeps: Alias[]) {
+  addHookAliases(pageDeps, "page");
   if (config.experimental.appDir) {
     if (config.experimental.serverActions) {
       addHookAliases(

--- a/packages/open-next/src/adapters/require-hooks.ts
+++ b/packages/open-next/src/adapters/require-hooks.ts
@@ -11,9 +11,10 @@ const resolveFilename = mod._resolveFilename;
 const hookPropertyMapApp = new Map();
 const hookPropertyMapPage = new Map();
 
-type Alias = [string, string];
-
-export function addHookAliases(aliases: Alias[] = [], type: "app" | "page") {
+export function addHookAliases(
+  aliases: [string, string][] = [],
+  type: "app" | "page"
+) {
   for (const [key, value] of aliases) {
     type === "app"
       ? hookPropertyMapApp.set(key, value)
@@ -36,8 +37,23 @@ export function overrideDefault() {
 }
 
 // Override built-in React packages if necessary
-export function overrideReact(config: NextConfig, pageDeps: Alias[]) {
-  addHookAliases(pageDeps, "page");
+export function overrideReact(config: NextConfig) {
+  addHookAliases(
+    [
+      ["react", require.resolve(`react`)],
+      ["react/jsx-runtime", require.resolve(`react/jsx-runtime`)],
+    ],
+    "page"
+  );
+
+  // ignore: react/jsx-dev-runtime is not available on older version of Next.js ie. v13.1.6
+  try {
+    addHookAliases(
+      [["react/jsx-dev-runtime", require.resolve(`react/jsx-dev-runtime`)]],
+      "page"
+    );
+  } catch (e) {}
+
   if (config.experimental.appDir) {
     if (config.experimental.serverActions) {
       addHookAliases(

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -7,6 +7,12 @@ import type {
   APIGatewayProxyEvent,
   CloudFrontRequestEvent,
 } from "aws-lambda";
+// We need to resolve those react deps before nextjs overrides them with prebundled one in case of app dir
+const node_react: [string, string][] = [
+  ["react", require.resolve(`react`)],
+  ["react/jsx-runtime", require.resolve(`react/jsx-runtime`)],
+  ["react/jsx-dev-runtime", require.resolve(`react/jsx-dev-runtime`)],
+];
 // @ts-ignore
 import NextServer from "next/dist/server/next-server.js";
 //@ts-ignore
@@ -131,7 +137,7 @@ function initializeNextjsRequireHooks(config: any) {
   // WORKAROUND: Set `__NEXT_PRIVATE_PREBUNDLED_REACT` to use prebundled React — https://github.com/serverless-stack/open-next#workaround-set-__next_private_prebundled_react-to-use-prebundled-react
   if (!isNextjsVersionAtLeast("13.1.3")) return;
   overrideDefault();
-  overrideReact(config);
+  overrideReact(config, node_react);
 }
 
 function setNextjsPrebundledReact(req: IncomingMessage, config: any) {

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { NextConfig } from "./next-types.js";
+import type { NextConfig, RoutesManifest } from "./next-types.js";
+import type { PublicFiles } from "../build.js";
 
 export function setNodeEnv() {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
@@ -15,4 +16,36 @@ export function loadConfig(nextDir: string) {
   const json = fs.readFileSync(filePath, "utf-8");
   const { config } = JSON.parse(json);
   return config as NextConfig;
+}
+
+export function loadHtmlPages(nextDir: string) {
+  const filePath = path.join(nextDir, "server", "pages-manifest.json");
+  const json = fs.readFileSync(filePath, "utf-8");
+  return Object.entries(JSON.parse(json))
+    .filter(([_, value]) => (value as string).endsWith(".html"))
+    .map(([key]) => key);
+}
+
+export function loadPublicAssets(openNextDir: string) {
+  const filePath = path.join(openNextDir, "public-files.json");
+  const json = fs.readFileSync(filePath, "utf-8");
+  return JSON.parse(json) as PublicFiles;
+}
+
+export function loadRoutesManifest(nextDir: string) {
+  const filePath = path.join(nextDir, "routes-manifest.json");
+  const json = fs.readFileSync(filePath, "utf-8");
+  return JSON.parse(json) as RoutesManifest;
+}
+
+export function loadAppPathsManifest(nextDir: string) {
+  const appPathsManifestPath = path.join(
+    nextDir,
+    "server",
+    "app-paths-manifest.json"
+  );
+  const appPathsManifestJson = fs.existsSync(appPathsManifestPath)
+    ? fs.readFileSync(appPathsManifestPath, "utf-8")
+    : "{}";
+  return JSON.parse(appPathsManifestJson) as Record<string, string>;
 }


### PR DESCRIPTION
This PR fix 2 issues:
- For users using monorepo without hoisting react at the root of the monorepo, `overrideDefault` was trying to resolve from the root
- `getMaybePagePath` has been replaced by some custom logic since it wasn't working for dynamic routes. (External dependencies could cause issue on these routes)