### PR TITLE
hash MessageDeduplicationId to avoid invalid values

### DIFF
--- a/.changeset/tame-papayas-change.md
+++ b/.changeset/tame-papayas-change.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+server: hash message dedup id


### PR DESCRIPTION
This PR should solve issue #138 the error happens when the page path is too long for the message MessageDeduplicationId
that needs to be less than 128 characters (see [documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html#API_SendMessage_RequestSyntax) )

I though about truncating the page path but if some pages share the same start of the (really long) path then we would get collisions on the message id potentially.