### PR TITLE
NextApiResponse: setHeader() and writeHead() should return `this`

### DIFF
--- a/.changeset/twenty-hounds-refuse.md
+++ b/.changeset/twenty-hounds-refuse.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Response: setHeader() and writeHead() return "this"

--- a/packages/open-next/src/adapters/response.ts
+++ b/packages/open-next/src/adapters/response.ts
@@ -70,6 +70,7 @@ export class ServerResponse extends http.ServerResponse {
     } else {
       super.setHeader(key, value);
     }
+    return this;
   }
 
   writeHead(statusCode, reason, obj) {
@@ -85,7 +86,7 @@ export class ServerResponse extends http.ServerResponse {
       }
     }
 
-    super.writeHead(statusCode, reason, obj);
+    return super.writeHead(statusCode, reason, obj);
   }
 
   constructor({ method }) {


### PR DESCRIPTION
With the API function `pages/api/test.ts`:
``` ts
export default async function handler(req: NextApiRequest, res: NextApiResponse) {
  res.status(405).setHeader('Allow', 'OPTIONS').end();
}
```

`GET /api/test` request should return `405 Method Not Allowed` HTTP response with `Allow: OPTIONS` header.
`next dev` works correctly  but compiled open-next server function returns `500 Internal Server Error`.

CloudWatch Logs says:
```
ERROR	TypeError: Cannot read properties of undefined (reading 'end')
    at handler (/var/task/apps/front/.next/server/pages/api/test.js:84:51)
    at /var/task/node_modules/next/dist/server/api-utils/node.js:463:16
    at /var/task/node_modules/next/dist/server/lib/trace/tracer.js:117:36
    at NoopContextManager.with (/var/task/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057)
    at ContextAPI.with (/var/task/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516)
    at NoopTracer.startActiveSpan (/var/task/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18086)
    at ProxyTracer.startActiveSpan (/var/task/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18847)
    at /var/task/node_modules/next/dist/server/lib/trace/tracer.js:106:107
    at NoopContextManager.with (/var/task/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057)
    at ContextAPI.with (/var/task/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516)
```

`setHeader()`, derived from http.OutgoingMessage, and `writeHead()`, derived from http.ServerResponse, are defined to return `this`.

This PR ensures to return `this` in both functions to complain interface definition.
