### PR TITLE
fix: missing html files for non blocking fallback page

### DIFF
--- a/.changeset/clever-waves-know.md
+++ b/.changeset/clever-waves-know.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix missing HTML files for non blocking fallback pages

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -343,6 +343,7 @@ function createCacheAssets(monorepoRoot: string) {
       file.endsWith(".js.nft.json") ||
       (file.endsWith(".html") && htmlPages.has(file))
   );
+
   // Copy fetch-cache to cache folder
   const fetchCachePath = path.join(appPath, ".next/cache/fetch-cache");
   if (fs.existsSync(fetchCachePath)) {
@@ -495,9 +496,7 @@ function addPublicFilesList(outputPath: string, packagePath: string) {
 function removeCachedPages(outputPath: string, packagePath: string) {
   // Pre-rendered pages will be served out from S3 by the cache handler
   const dotNextPath = path.join(outputPath, packagePath);
-  // We should not remove html files that are in the format of [param].html
-  // because they are used for `fallback:true` pages.
-  const htmlRegex = /^(?!.*\[.*\]\.html).*\.html$/;
+  const isFallbackTruePage = /\[.*\]/;
   const htmlPages = getHtmlPages(dotNextPath);
   [".next/server/pages", ".next/server/app"]
     .map((dir) => path.join(dotNextPath, dir))
@@ -509,7 +508,12 @@ function removeCachedPages(outputPath: string, packagePath: string) {
           file.endsWith(".json") ||
           file.endsWith(".rsc") ||
           file.endsWith(".meta") ||
-          (htmlRegex.test(file) && !htmlPages.has(file))
+          (file.endsWith(".html") &&
+            // do not remove static HTML files
+            !htmlPages.has(file) &&
+            // do not remove HTML files with "[param].html" format
+            // b/c they are used for "fallback:true" pages
+            !isFallbackTruePage.test(file))
       )
     );
 }

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -343,7 +343,6 @@ function createCacheAssets(monorepoRoot: string) {
       file.endsWith(".js.nft.json") ||
       (file.endsWith(".html") && htmlPages.has(file))
   );
-
   // Copy fetch-cache to cache folder
   const fetchCachePath = path.join(appPath, ".next/cache/fetch-cache");
   if (fs.existsSync(fetchCachePath)) {
@@ -496,6 +495,9 @@ function addPublicFilesList(outputPath: string, packagePath: string) {
 function removeCachedPages(outputPath: string, packagePath: string) {
   // Pre-rendered pages will be served out from S3 by the cache handler
   const dotNextPath = path.join(outputPath, packagePath);
+  // We should not remove html files that are in the format of [param].html
+  // because they are used for `fallback:true` pages.
+  const htmlRegex = /^(?!.*\[.*\]\.html).*\.html$/;
   const htmlPages = getHtmlPages(dotNextPath);
   [".next/server/pages", ".next/server/app"]
     .map((dir) => path.join(dotNextPath, dir))
@@ -507,7 +509,7 @@ function removeCachedPages(outputPath: string, packagePath: string) {
           file.endsWith(".json") ||
           file.endsWith(".rsc") ||
           file.endsWith(".meta") ||
-          (file.endsWith(".html") && !htmlPages.has(file))
+          (htmlRegex.test(file) && !htmlPages.has(file))
       )
     );
 }


### PR DESCRIPTION
For pages using `fallback:true`, we need to keep the html files. This PR fix this