### PR TITLE
Additional framework for CDK with support for TS,Java,Go,Py,.NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ For more information, check out the SST docs: https://docs.sst.dev/start/nextjs
 
 The OpenNext community has contributed deployment options for a few other frameworks.
 
-- CDK: https://github.com/jetbridge/cdk-nextjs
+- CDK (TS): https://github.com/jetbridge/cdk-nextjs
+- CDK (TS,Java,Go,Py,.NET): https://github.com/datasprayio/open-next-cdk
 - CloudFormation: https://github.com/serverless-stack/open-next/issues/32
 - Serverless Framework: https://github.com/serverless-stack/open-next/issues/32
 - Terraform: https://github.com/RJPearson94/terraform-aws-open-next

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For more information, check out the SST docs: https://docs.sst.dev/start/nextjs
 The OpenNext community has contributed deployment options for a few other frameworks.
 
 - CDK (TS): https://github.com/jetbridge/cdk-nextjs
-- CDK (TS,Java,Go,Py,.NET): https://github.com/datasprayio/open-next-cdk
+- CDK (TS, Java, Go, Py, .NET): https://github.com/datasprayio/open-next-cdk
 - CloudFormation: https://github.com/serverless-stack/open-next/issues/32
 - Serverless Framework: https://github.com/serverless-stack/open-next/issues/32
 - Terraform: https://github.com/RJPearson94/terraform-aws-open-next


### PR DESCRIPTION
Adding a CDK framework forked from jetbridge/cdk-nextjs to support all other JSII languages. I needed to get it packaged for Java and thought others may benefit from it.